### PR TITLE
fixed server.cfg error

### DIFF
--- a/server.cfg
+++ b/server.cfg
@@ -47,7 +47,7 @@ ensure [esxaddon]
 ensure [esxjobs]
 exec maps.cfg
 exec phone.cfg
-exec iventroy.cfg
+exec inventory.cfg
 ensure [extras]
 ################## RESSOURCEN ##################
 


### PR DESCRIPTION
server.cfg Error Fix, Falsche Benennung der inventory.cfg.